### PR TITLE
Add fonts, styling and fixed meeple removal

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -10,6 +10,7 @@ class Game {
     this.currentTile = null;
     this.player1 = null;
     this.player2 = null;
+    this.players = [];
     this.currentPlayer = null;
     this.currentMeeple = null;
     this.setup();
@@ -25,6 +26,7 @@ class Game {
     this.tileInventory = new TileInventory();
     this.player1 = new Player("Kimi", "red");
     this.player2 = new Player("Scott", "blue");
+    this.players = [this.player1, this.player2];
     this.currentPlayer = this.player2;
     this.currentTile = this.tileInventory.nextTile();
     $('.board').append(this.currentTile.dom);
@@ -45,10 +47,14 @@ class Game {
   }
 
   nextTurn(e) {
+    this.currentPlayer.playerInfo.dom.addClass('dim');
     this.changeCurrentPlayer();
+    this.currentPlayer.playerInfo.dom.removeClass('dim');
+    this.currentTile.removeBorder();
     this.currentTile = this.tileInventory.nextTile();
     this.currentTile.setPosition(100, 100);
     this.currentTile.activate();
+    this.currentTile.dom.addClass(`${this.currentPlayer.color}-border`);
     this.updateTileCount();
   }
 
@@ -110,7 +116,7 @@ class Game {
     // meeple can only be placed on current tile
     if (inXRange && inYRange) {
       this.currentMeeple.setPosition(meeplePosition.x, meeplePosition.y);
-      this.currentMeeple.dom.on('click', this.removeMeeple.bind(this));
+      this.currentMeeple.dom.on('click', this.targetMeeple.bind(this));
       this.currentMeeple.deactivate();
       meeplesPlayed.push(meeplesUnplayed.shift());
       this.currentPlayer.playerInfo.updateMeepleCount();
@@ -128,18 +134,29 @@ class Game {
     this.nextTurn();
   }
 
-  removeMeeple(e) {
-    let meeplesUnplayed = this.currentPlayer.meepleInventory.meeplesUnplayed;
-    let meeplesPlayed = this.currentPlayer.meepleInventory.meeplesPlayed;
-    let thisMeepleId = e.currentTarget.id.charAt(0);
-    let $targetedMeeple = $.grep(meeplesPlayed, function(e){ return e.id == thisMeepleId; })[0];
+  targetMeeple(e) {
+    let thisMeepleColor = e.target.id.split('-')[2];
+    let thisMeepleId = e.target.id.split('-')[0];
+
+    for (let player of this.players) {
+      if (player.color === thisMeepleColor) {
+        for (let meeple of player.meepleInventory.meeplesPlayed) {
+          if (String(meeple.id) === thisMeepleId) {
+            this.removeMeeple.call(meeple, player);
+          }
+        }
+      }
+    }
+  }
+
+  removeMeeple(player) {
     if (confirm('Remove Meeple?')) {
-      $targetedMeeple.setPosition(0, 0);
-      $targetedMeeple.dom.off('click');
-      let index = meeplesPlayed.indexOf($targetedMeeple);
-      meeplesUnplayed.push($targetedMeeple);
-      meeplesPlayed.splice(index, 1);
-      $targetedMeeple.hide();
+      this.setPosition(0, 0);
+      this.dom.off('click');
+      let index = player.meepleInventory.meeplesPlayed.indexOf(this);
+      player.meepleInventory.meeplesUnplayed.push(this);
+      player.meepleInventory.meeplesPlayed.splice(index, 1);
+      this.hide();
     };
   }
 

--- a/lib/game.js
+++ b/lib/game.js
@@ -156,6 +156,7 @@ class Game {
       let index = player.meepleInventory.meeplesPlayed.indexOf(this);
       player.meepleInventory.meeplesUnplayed.push(this);
       player.meepleInventory.meeplesPlayed.splice(index, 1);
+      player.playerInfo.updateMeepleCount();
       this.hide();
     };
   }

--- a/lib/meeple.js
+++ b/lib/meeple.js
@@ -12,7 +12,7 @@ class Meeple {
   buildDom() {
     this.dom = $('<div>', { class: 'meeple' });
     this.dom.css('background-image', `url('lib/images/meeples/meeple-${this.color}.png')`);
-    this.dom.attr('id', `${this.id}-meeple`);
+    this.dom.attr('id', `${this.id}-meeple-${this.color}`);
     this.dom.css('left', this.x);
     this.dom.css('top', this.y);
     this.dom.css('display', 'none');

--- a/lib/playerInfo.js
+++ b/lib/playerInfo.js
@@ -69,7 +69,7 @@ class PlayerInfo {
     this.scoreValueDom.html(`Score: ${this.score}`)
   }
 
-  updateMeepleCount(count) {
+  updateMeepleCount() {
     this.remainingMeeples = this.player.meepleInventory.meeplesUnplayed.length;
     this.meepleCountDom.html(`Meeples: ${this.remainingMeeples}`);
   }

--- a/lib/playerInfo.js
+++ b/lib/playerInfo.js
@@ -14,7 +14,7 @@ class PlayerInfo {
     this.dom = $('<div>', { class: 'player-pane' });
     this.dom.css('left', 100);
     this.dom.css('top', 300);
-    this.dom.css('background-color', this.player.color);
+    this.dom.addClass(`${this.player.color}-background`);
     this.dom.css('color', "white");
 
     /* build player name */
@@ -52,8 +52,7 @@ class PlayerInfo {
   }
 
   addEventListeners() {
-    this.dom.find('.add-to-score').on('click',                this.addToPlayerScore.bind(this.player));
-
+    this.dom.find('.add-to-score').on('click', this.addToPlayerScore.bind(this.player));
     this.dom.find('.subtract-from-score').on('click', this.subtractFromPlayerScore.bind(this.player));
   }
 

--- a/lib/style.scss
+++ b/lib/style.scss
@@ -1,7 +1,25 @@
+/* Fonts */
+@import url(https://fonts.googleapis.com/css?family=Marck+Script);
+@import url(https://fonts.googleapis.com/css?family=Courgette);
+@import url(https://fonts.googleapis.com/css?family=MedievalSharp);
+@import url(https://fonts.googleapis.com/css?family=UnifrakturMaguntia);
+
+$medieval-font: 'UnifrakturMaguntia', cursive;
+$main-font: 'Marck Script', cursive;
+$secondary-font: 'MedievalSharp', cursive;
+
+/* Colors */
+$red: rgb(202,8,19);
+$blue: rgb(28,71,127);
+
 body {
   position: relative;
   margin: 0;
   padding: 0;
+}
+
+div {
+  box-sizing: border-box;
 }
 
 .view {
@@ -50,6 +68,7 @@ body {
 #tiles-remaining {
   position: absolute;
   color: white;
+  font-family: $medieval-font;
   font-size: 30px;
   top: 20px;
   left: 50px;
@@ -62,8 +81,16 @@ body {
 .current-tile {
   top: 0;
   right: 0;
-  border: 3px solid white;
+  border: 3px solid;
   z-index: 1;
+}
+
+.red-border {
+  border-color: $red;
+}
+
+.blue-border {
+  border-color: $blue;
 }
 
 .tile {
@@ -80,6 +107,7 @@ body {
   width: 25px;
   height: 25px;
   background-size: cover;
+  z-index: 2;
 }
 
 /* rotations */
@@ -127,6 +155,7 @@ body {
   z-index: 10;
   top: 250px;
   left: 50px;
+  font-family: $secondary-font;
 }
 
 .player-pane {
@@ -137,6 +166,18 @@ body {
   width: 175px;
   height: 175px;
   padding-left: 20px;
+}
+
+.dim {
+  opacity: 0.5;
+}
+
+.red-background {
+  background-color: $red;
+}
+
+.blue-background {
+  background-color: $blue;
 }
 
 .player-name {

--- a/lib/tile.js
+++ b/lib/tile.js
@@ -62,8 +62,11 @@ class Tile {
     this.dom.off('mouseover', this.tileMouseOver);
     this.dom.off('mouseout', this.tileMouseOut);
     this.dom.draggable('disable');
-    this.dom.removeClass('current-tile');
     this.domRotate.remove();
+  }
+
+  removeBorder() {
+    this.dom.removeClass('current-tile');
   }
 
   get position() {


### PR DESCRIPTION
Styling helps show which players turn it is by adding that color to the current tile border and by dimming the other player's info panel.

Added some fonts. We can play around more with which ones we like if we want to.

Fixed the meeple removal button so that it targets the correct meeple based on the event click target.

closes #20 
