### PR TITLE
Tiles can only be placed next to other tiles

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -31,6 +31,10 @@
   "white": false,
   "eqnull": true,
   "esnext": true,
-  "unused": true,
-  "mocha": true
+  "mocha": true,
+  "jquery": true,
+  "TimelineMax": false,
+  "_": false,
+  "unused": vars,
+  "esversion": 2015
 }

--- a/lib/game.js
+++ b/lib/game.js
@@ -157,9 +157,9 @@ class Game {
 
   placeTile(e) {
     let position = this.currentTile.position;
-
-    let isValid = this.tileInventory.isPositionValid(position.x, position.y);
-    if (isValid) {
+    let isOpen = this.tileInventory.isPositionOpen(position.x, position.y);
+    let isAdjacent = this.tileInventory.isPositionAdjacent(position.x, position.y);
+    if (isAdjacent && isOpen) {
       this.currentTile.setPosition(position.x, position.y);
       this.tileInventory.addAdjacentCoordinates(position.x, position.y);
       this.currentTile.deactivate();

--- a/lib/game.js
+++ b/lib/game.js
@@ -114,6 +114,7 @@ class Game {
     this.currentTile = this.tileInventory.nextTile();
     dom('gameBoard').append(this.currentTile.dom);
     this.currentTile.setPosition(500, 500);
+    this.tileInventory.addAdjacentCoordinates(this.currentTile.x, this.currentTile.y);
     this.currentTile.dom.draggable({ snap: true });
     this.currentTile.dom.draggable('disable');
   }
@@ -156,9 +157,11 @@ class Game {
 
   placeTile(e) {
     let position = this.currentTile.position;
-    let isValid = this.tileInventory.isPositionOpen(position.x, position.y);
+
+    let isValid = this.tileInventory.isPositionValid(position.x, position.y);
     if (isValid) {
       this.currentTile.setPosition(position.x, position.y);
+      this.tileInventory.addAdjacentCoordinates(position.x, position.y);
       this.currentTile.deactivate();
       if (this.currentPlayer.meepleInventory.meeplesUnplayed.length > 0) {
         this.showPlaceMeepleButtons();
@@ -167,7 +170,7 @@ class Game {
         this.nextTurn();
       }
     } else {
-      alert("Pick a location that hasn't been taken!");
+      alert("This is an invalid position");
     }
   }
 

--- a/lib/grid.js
+++ b/lib/grid.js
@@ -1,4 +1,4 @@
-var config = require('./config').info;
+let config = require('./config').info;
 
 class Grid {
   constructor() {

--- a/lib/playerInfo.js
+++ b/lib/playerInfo.js
@@ -30,7 +30,7 @@ class PlayerInfo {
     this.scoreDom = $('<div>', { class: 'player-score' });
     this.scoreValueDom = $('<h3>', { class: 'player-score-value' });
     this.scoreValueDom.append(`Score: ${this.player.score}`);
-    this.scoreButtons = $('<div>', { class: 'score-buttons'} )
+    this.scoreButtons = $('<div>', { class: 'score-buttons'} );
     this.scoreDom.append(this.scoreValueDom);
   }
 

--- a/lib/tile.js
+++ b/lib/tile.js
@@ -57,11 +57,7 @@ class Tile {
 
   deactivate() {
     // Cleanup listeners
-    this.dom.off('mousedown', this.tileMouseDown);
-    this.dom.off('mouseup', this.tileMouseUp);
-    this.dom.off('mousemove', this.tileMouseMove);
-    this.dom.off('mouseover', this.tileMouseOver);
-    this.dom.off('mouseout', this.tileMouseOut);
+    this.dom.off();
     this.dom.draggable('disable');
     this.domRotate.remove();
   }

--- a/lib/tile.js
+++ b/lib/tile.js
@@ -93,7 +93,7 @@ class Tile {
         this.dom.addClass('rotate180');
       } else if (this.dom.hasClass('rotate180')) {
         this.dom.removeClass('rotate180');
-        this.dom.addClass('rotate270')
+        this.dom.addClass('rotate270');
       } else if (this.dom.hasClass('rotate270')) {
         this.dom.removeClass('rotate270');
       } else {

--- a/lib/tileInventory.js
+++ b/lib/tileInventory.js
@@ -1,9 +1,10 @@
-var _ = require('lodash');
-var Tile = require('./tile');
+let _ = require('lodash');
+let Tile = require('./tile');
+let config = require('./config').info;
 
 class TileInventory {
   constructor() {
-    this.config = {
+    this.tileConfig = {
       borderTypes: [ 'field', 'road', 'city' ],
       tileTypes: {
         A: { quantity: 2, borders: [ 'field', 'field', 'road', 'field' ], pennant: false },
@@ -36,17 +37,18 @@ class TileInventory {
 
     this.tilesUnplayed = [];
     this.tilesPlayed = [];
+    this.validPositions = [];
   }
 
   build() {
-    for (let tileType of Object.keys(this.config.tileTypes)) {
-      let tileInfo = this.config.tileTypes[tileType];
+    for (let tileType of Object.keys(this.tileConfig.tileTypes)) {
+      let tileInfo = this.tileConfig.tileTypes[tileType];
       for (let i=0; i<tileInfo.quantity; i++) {
         this.addTile(tileType, tileInfo);
       }
     }
     this.tilesUnplayed = _.shuffle(this.tilesUnplayed);
-    this.addTile(this.config.tileStart, this.config.tileTypes[this.config.tileStart]);
+    this.addTile(this.tileConfig.tileStart, this.tileConfig.tileTypes[this.tileConfig.tileStart]);
   }
 
   addTile(type, info) {
@@ -78,9 +80,28 @@ class TileInventory {
     return true;
   }
 
-  validPositions() {
-    let validPositions = [];
+  addAdjacentCoordinates(x, y) {
+    let left = [ x - config('tileWidth'), y ];
+    let right = [ x + config('tileWidth'), y ];
+    let top = [ x, y - config('tileHeight') ];
+    let bottom = [ x, y + config('tileHeight') ];
+    let adjacentCoordinates = [top, right, bottom, left];
 
+    // push coordinates into validPositions array if the position is open
+    for (let position of adjacentCoordinates) {
+      if (this.isPositionOpen(position[0], position[1])) {
+        this.validPositions.push(position);
+      }
+    }
+  }
+
+  isPositionValid(x, y) {
+    for (let position of this.validPositions) {
+      if (position[0] === x && position[1] === y) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 

--- a/lib/tileInventory.js
+++ b/lib/tileInventory.js
@@ -37,7 +37,7 @@ class TileInventory {
 
     this.tilesUnplayed = [];
     this.tilesPlayed = [];
-    this.validPositions = [];
+    this.adjacentPositions = [];
   }
 
   build() {
@@ -87,16 +87,16 @@ class TileInventory {
     let bottom = [ x, y + config('tileHeight') ];
     let adjacentCoordinates = [top, right, bottom, left];
 
-    // push coordinates into validPositions array if the position is open
+    // push coordinates into adjacentPositions array if the position is open
     for (let position of adjacentCoordinates) {
       if (this.isPositionOpen(position[0], position[1])) {
-        this.validPositions.push(position);
+        this.adjacentPositions.push(position);
       }
     }
   }
 
-  isPositionValid(x, y) {
-    for (let position of this.validPositions) {
+  isPositionAdjacent(x, y) {
+    for (let position of this.adjacentPositions) {
       if (position[0] === x && position[1] === y) {
         return true;
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "webpack-dev-server": "^1.10.1"
   },
   "dependencies": {
+    "eslint": "^2.10.2",
     "lodash": "^4.12.0"
   }
 }

--- a/test/tile-inventory-test.js
+++ b/test/tile-inventory-test.js
@@ -19,4 +19,17 @@ describe('TileInventory', () => {
       assert.isFalse(tileInventory.isPositionOpen(100, 100));
     });
   });
+
+  describe('findAdjacentCoordinates', () => {
+    it('adds x and y coordinates of position around tile to validPositions array', () => {
+      let tileInventory = new TileInventory();
+      let tile1 = new Tile("image.jpg", "A", "field", "road", "field", "city", false, 100, 100);
+      let tile2 = new Tile("image.jpg", "A", "field", "road", "field", "city", false, 200, 200);
+      let tile3 = new Tile("image.jpg", "A", "field", "road", "field", "city", false, 300, 300);
+
+      tileInventory.findAdjacentCoordinates(500, 500);
+      let expected = [ [ 500, 400 ], [ 600, 500 ], [ 500, 600 ], [ 400, 500 ] ]
+      assert.deepEqual(tileInventory.validPositions, expected, "finds valid coordinates");
+    });
+  });
 });

--- a/test/tile-inventory-test.js
+++ b/test/tile-inventory-test.js
@@ -20,16 +20,16 @@ describe('TileInventory', () => {
     });
   });
 
-  describe('findAdjacentCoordinates', () => {
-    it('adds x and y coordinates of position around tile to validPositions array', () => {
+  describe('addAdjacentCoordinates', () => {
+    it('adds x and y coordinates of position around tile to adjacentPositions array', () => {
       let tileInventory = new TileInventory();
       let tile1 = new Tile("image.jpg", "A", "field", "road", "field", "city", false, 100, 100);
       let tile2 = new Tile("image.jpg", "A", "field", "road", "field", "city", false, 200, 200);
       let tile3 = new Tile("image.jpg", "A", "field", "road", "field", "city", false, 300, 300);
 
-      tileInventory.findAdjacentCoordinates(500, 500);
+      tileInventory.addAdjacentCoordinates(500, 500);
       let expected = [ [ 500, 400 ], [ 600, 500 ], [ 500, 600 ], [ 400, 500 ] ]
-      assert.deepEqual(tileInventory.validPositions, expected, "finds valid coordinates");
+      assert.deepEqual(tileInventory.adjacentPositions, expected, "finds adjacent coordinates");
     });
   });
 });


### PR DESCRIPTION
Add adjacent coordinates to valid positions array. Tiles can only be placed next to previously played tiles and cannot be placed on top of each other. All event listeners are removed after the tile is placed.

closes #30 
