### PR TITLE
Add logic to prevent cross site scripting

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -65,7 +65,9 @@ class Game {
       ];
 
     for (let field of fields) {
-      if (/^\s*$/.test(field.val())) {
+      if (field.val().includes('<') || field.val().includes('>')) {
+        field.val(`Player ${field[0].id.slice(-1)}`);
+      } else if (/^\s*$/.test(field.val())) {
         field.val(`Player ${field[0].id.slice(-1)}`);
       } else if (field.val().length > 12) {
         field.val(field.val().substring(0, 12) + "...");


### PR DESCRIPTION
If '<' and/or '>' are entered as names they are replaced by 'PlayerX'

closes #45 
