### PR TITLE
Add file loader to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-loader": "^5.3.2",
     "chai": "^3.2.0",
     "css-loader": "^0.15.5",
+    "file-loader": "^0.8.5",
     "mocha": "^2.2.5",
     "mocha-loader": "^0.7.1",
     "node-libs-browser": "^0.5.2",


### PR DESCRIPTION
@scottfirestone: This file-loader is necessary for others to load our game properly. We may have installed it globally on our computers which is why it worked without adding it to package.json.
